### PR TITLE
Add GitHub Actions testing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,32 @@
+name: build
+
+on:
+  push:
+    branches-ignore:
+      - "debian/**"
+      - "pristine-tar"
+      - "ubuntu/**"
+      - "upstream/**"
+    tags:
+      - "release/*"
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  perl:
+    env:
+      AUTHOR_TESTING: 1
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install prerequisites
+        run: sudo apt-get install gnupg gnupg1 libmodule-build-perl
+      - name: perl -V
+        run: perl -V
+      - name: Build.PL
+        run: perl Build.PL
+      - name: make test
+        run: ./Build test


### PR DESCRIPTION
Test with Perl versions back to 5.20 (the version in Debian
old-oldstable).  Install both gnupg and gnupg1, although only the
latter will be used for now.